### PR TITLE
Use scikit-learn instead of sklearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "pytorch-lightning",
         "wandb",
         "matplotlib",
-        "sklearn",
+        "scikit-learn",
         "numpy",
         "pandas",
         "loguru",


### PR DESCRIPTION
scikit-learn is deprecating the use of sklearn. I have consequently updated it in setup.py